### PR TITLE
feat / Integrate react router (resolves #77, #78)

### DIFF
--- a/client/components/App.jsx
+++ b/client/components/App.jsx
@@ -1,10 +1,8 @@
 import React from 'react';
 import Main from './Main.jsx';
 import Nav from './Nav.jsx';
-import Landing from './Landing.jsx';
 
-
-const App = (props) => (
+const App = () => (
   <div>
     <Nav />
     <Main />

--- a/client/components/App.jsx
+++ b/client/components/App.jsx
@@ -7,7 +7,7 @@ import Landing from './Landing.jsx';
 const App = (props) => (
   <div>
     <Nav />
-    { true ? <Main /> : <Landing /> }
+    <Main />
   </div>
 );
 

--- a/client/components/Landing.jsx
+++ b/client/components/Landing.jsx
@@ -1,7 +1,9 @@
 import React from 'react';
+import Nav from './Nav.jsx';
 
 const Landing = () => (
   <div>
+     <Nav />
      <div className="intro-header">
          <div className="container">
              <div className="row">

--- a/client/index.jsx
+++ b/client/index.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import { Router, Route, Link } from 'react-router';
 import App from './components/App.jsx';
+import Landing from './components/Landing.jsx';
 import { Provider } from 'react-redux';
 import configureStore from './store/configureStore';
 import styles from './styles/entry.scss';
@@ -30,7 +32,10 @@ loadData(3);
 
 ReactDOM.render(
   <Provider store={store}>
-    <App />
+    <Router>
+      <Route path="/" component={Landing} />
+      <Route path="/demo" component={App} />
+    </Router>
   </Provider>,
   document.getElementById('app')
 );

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "react-chartjs": "^0.7.3",
     "react-dom": "^15.0.0",
     "react-redux": "^4.4.5",
+    "react-router": "^2.4.0",
     "redux": "^3.4.0",
     "request": "^2.72.0",
     "rewire": "^2.5.1",

--- a/server/server.js
+++ b/server/server.js
@@ -26,17 +26,23 @@ passport.use(new LocalStrategy({
   usernameField: 'email',
 }, authenticate));
 
-app.use(passport.initialize());
-app.use(passport.session()); // must come after express session
+/*
+ * The following code integrates passport.js and implements a local storage
+ * for user authentication. It's not necessary for the demo and should be removed
+ * from the final code that we push to github, to avoid confusing anyone.
+ */
 
-app.get('/login', function(req, res) {
-  res.redirect('/login.html');
-});
-
-app.post('/login', passport.authenticate('local', { failureRedirect: '/login' }),
-  function(req, res) {
-    res.redirect('/');
-});
+// app.use(passport.initialize());
+// app.use(passport.session()); // must come after express session
+//
+// app.get('/login', function(req, res) {
+//   res.redirect('/login.html');
+// });
+//
+// app.post('/login', passport.authenticate('local', { failureRedirect: '/login' }),
+//   function(req, res) {
+//     res.redirect('/');
+// });
 
 app.listen(port, (err) => {
   if (err) { throw new Error(err); }


### PR DESCRIPTION
- Integrates `react-router`
- Renders the landing page at `/`
- Renders the `App` component at `/#/demo`
- Makes a few minor cleanup changes
- Comments out the passport authentication code from `server.js`
